### PR TITLE
feat: add helm chart

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,37 @@
+---
+name: release-charts
+on:
+  push:
+    # Release changed helm charts from `charts/` whenever a
+    # merge/push into `main` occurs.
+    #
+    # The packaged charts are stored in the `gh-pages` branch, the helm
+    # repository is served via GitHub Pages.
+    #
+    # See: https://github.com/helm/chart-releaser-action
+    branches:
+      - main
+
+jobs:
+  release-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3.3
+        with:
+          version: v3.7.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.4.1
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,46 @@ the listen address via the `--listen-address` flag.
 The exporter will listen on `0.0.0.0:8080` by default and exposes prometheus
 metrics at `/metrics` and a health endpoint at `/healthz`.
 
+## Deployment
+
+The helm chart provided in this repository can be used to deploy the metrics exporter.
+
+First, add the helm repository:
+
+```sh
+helm repo add spotinst-metrics-exporter \
+  https://bonial-international-gmbh.github.io/spotinst-metrics-exporter
+```
+
+Create a `values.yaml` and add a `spotinst` section with the account ID and
+token, for example:
+
+```yaml
+---
+spotinst:
+  account: act-12345678
+  token: the-spotinst-token
+```
+
+For more helm configuration options have a look into the [`values.yaml`
+defaults](https://github.com/Bonial-International-GmbH/spotinst-metrics-exporter/blob/main/charts/spotinst-metrics-exporter/values.yaml).
+
+Finally use helm to install the metrics exporter:
+
+```sh
+helm upgrade spotinst-metrics-exporter spotinst-metrics-exporter/spotinst-metrics-exporter \
+  --install --namespace kube-system --values values.yaml
+```
+
+Alternatively, you can also pass `spotinst.account` and `spotinst.token` to the
+`helm` command directly instead of using a `values.yaml` file:
+
+```sh
+helm upgrade spotinst-metrics-exporter spotinst-metrics-exporter/spotinst-metrics-exporter \
+  --install --namespace kube-system \
+  --set spotinst.account=act-12345678,spotinst.token=the-spotinst-token
+```
+
 ## Metrics
 
 All metrics are gauge values. The values of CPU metrics are in milli-CPU,

--- a/charts/spotinst-metrics-exporter/.helmignore
+++ b/charts/spotinst-metrics-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/spotinst-metrics-exporter/Chart.yaml
+++ b/charts/spotinst-metrics-exporter/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: spotinst-metrics-exporter
+description: A prometheus exporter for metrics from Spotinst
+type: application
+version: 0.0.1
+appVersion: "v0.0.1"

--- a/charts/spotinst-metrics-exporter/templates/_helpers.tpl
+++ b/charts/spotinst-metrics-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "spotinst-metrics-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "spotinst-metrics-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "spotinst-metrics-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "spotinst-metrics-exporter.labels" -}}
+helm.sh/chart: {{ include "spotinst-metrics-exporter.chart" . }}
+{{ include "spotinst-metrics-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "spotinst-metrics-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "spotinst-metrics-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "spotinst-metrics-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "spotinst-metrics-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/spotinst-metrics-exporter/templates/deployment.yaml
+++ b/charts/spotinst-metrics-exporter/templates/deployment.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "spotinst-metrics-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spotinst-metrics-exporter.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "spotinst-metrics-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "spotinst-metrics-exporter.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "spotinst-metrics-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ include "spotinst-metrics-exporter.fullname" . }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/spotinst-metrics-exporter/templates/secret.yaml
+++ b/charts/spotinst-metrics-exporter/templates/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "spotinst-metrics-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spotinst-metrics-exporter.labels" . | nindent 4 }}
+data:
+  SPOTINST_ACCOUNT: {{ required ".Values.spotinst.account is required" .Values.spotinst.account | b64enc }}
+  SPOTINST_TOKEN: {{ required ".Values.spotinst.token is required" .Values.spotinst.token | b64enc }}

--- a/charts/spotinst-metrics-exporter/templates/service.yaml
+++ b/charts/spotinst-metrics-exporter/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spotinst-metrics-exporter.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "spotinst-metrics-exporter.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "spotinst-metrics-exporter.selectorLabels" . | nindent 4 }}

--- a/charts/spotinst-metrics-exporter/templates/serviceaccount.yaml
+++ b/charts/spotinst-metrics-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "spotinst-metrics-exporter.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "spotinst-metrics-exporter.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/spotinst-metrics-exporter/values.yaml
+++ b/charts/spotinst-metrics-exporter/values.yaml
@@ -1,0 +1,54 @@
+# Default values for spotinst-metrics-exporter.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/bonial-international-gmbh/spotinst-metrics-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: false
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use. If not set and create is true, a
+  # name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 65534
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+
+resources: {}
+  # limits:
+  #   memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+spotinst:
+  account: ""
+  token: ""


### PR DESCRIPTION
This change adds a helm chart for `spotinst-metrics-exporter` and a workflow which will automatically publish the chart to GitHub Pages whenever there is a change in the `main` branch.

GitHub Pages was already enabled and the `gh-pages` branch exists.

This is identically to how we do it for `pod-image-swap-webhook` except that the chart is a bit simpler since it does not require any of the webhook-specific resources.

Have a look at the `README.md` to see how it's used.