### PR TITLE
feat: add `ocean_name` to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,20 +73,20 @@ running costs of the current month and are reset on every 1st.
 ### Samples
 
 ```
-spotinst_ocean_aws_cluster_cost{ocean="o-12345678"} 301.86862
-spotinst_ocean_aws_daemonset_cost{name="kube-proxy",namespace="kube-system",ocean="o-12345678"} 3.4616985
-spotinst_ocean_aws_deployment_cost{name="coredns",namespace="kube-system",ocean="o-12345678"} 1.2382613
-spotinst_ocean_aws_job_cost{name="kube-janitor-default-27752145",namespace="sdlc-ops",ocean="o-12345678"} 0.0021596102
-spotinst_ocean_aws_namespace_cost{namespace="kube-system",ocean="o-12345678"} 28.858004
-spotinst_ocean_aws_statefulset_cost{name="jenkins",namespace="jenkins",ocean="o-12345678"} 2.004659
-spotinst_ocean_aws_workload_container_cpu_requested{container="coredns",name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 100
-spotinst_ocean_aws_workload_container_cpu_suggested{container="coredns",name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 100
-spotinst_ocean_aws_workload_container_memory_requested{container="coredns",name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 70
-spotinst_ocean_aws_workload_container_memory_suggested{container="coredns",name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 34
-spotinst_ocean_aws_workload_cpu_requested{name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 100
-spotinst_ocean_aws_workload_cpu_suggested{name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 100
-spotinst_ocean_aws_workload_memory_requested{name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 70
-spotinst_ocean_aws_workload_memory_suggested{name="coredns",namespace="kube-system",ocean="o-12345678",workload="deployment"} 34
+spotinst_ocean_aws_cluster_cost{ocean_id="o-12345678",ocean_name="my-ocean"} 301.86862
+spotinst_ocean_aws_daemonset_cost{name="kube-proxy",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 3.4616985
+spotinst_ocean_aws_deployment_cost{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 1.2382613
+spotinst_ocean_aws_job_cost{name="kube-janitor-default-27752145",namespace="sdlc-ops",ocean_id="o-12345678",ocean_name="my-ocean"} 0.0021596102
+spotinst_ocean_aws_namespace_cost{namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 28.858004
+spotinst_ocean_aws_statefulset_cost{name="jenkins",namespace="jenkins",ocean_id="o-12345678",ocean_name="my-ocean"} 2.004659
+spotinst_ocean_aws_workload_container_cpu_requested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
+spotinst_ocean_aws_workload_container_cpu_suggested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
+spotinst_ocean_aws_workload_container_memory_requested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 70
+spotinst_ocean_aws_workload_container_memory_suggested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 34
+spotinst_ocean_aws_workload_cpu_requested{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
+spotinst_ocean_aws_workload_cpu_suggested{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
+spotinst_ocean_aws_workload_memory_requested{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 70
+spotinst_ocean_aws_workload_memory_suggested{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 34
 ```
 
 ## License

--- a/pkg/collectors/ocean_aws_cluster_costs_test.go
+++ b/pkg/collectors/ocean_aws_cluster_costs_test.go
@@ -76,13 +76,13 @@ func TestOceanAWSClusterCostsCollector(t *testing.T) {
 			expected: `
                 # HELP spotinst_ocean_aws_cluster_cost Total cost of an ocean cluster
                 # TYPE spotinst_ocean_aws_cluster_cost gauge
-                spotinst_ocean_aws_cluster_cost{ocean="foo"} 200
+                spotinst_ocean_aws_cluster_cost{ocean_id="foo",ocean_name="ocean-foo"} 200
                 # HELP spotinst_ocean_aws_namespace_cost Total cost of a namespace
                 # TYPE spotinst_ocean_aws_namespace_cost gauge
-                spotinst_ocean_aws_namespace_cost{namespace="foo-ns",ocean="foo"} 190
+                spotinst_ocean_aws_namespace_cost{namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo"} 190
                 # HELP spotinst_ocean_aws_deployment_cost Total cost of a deployment
                 # TYPE spotinst_ocean_aws_deployment_cost gauge
-                spotinst_ocean_aws_deployment_cost{name="foo-deployment",namespace="foo-ns",ocean="foo"} 180
+                spotinst_ocean_aws_deployment_cost{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo"} 180
             `,
 		},
 	}
@@ -106,6 +106,7 @@ func oceanClusters(clusterIDs ...string) []*aws.Cluster {
 		clusters = append(clusters, &aws.Cluster{
 			ID:                  spotinst.String(id),
 			ControllerClusterID: spotinst.String(id),
+			Name:                spotinst.String("ocean-" + id),
 		})
 	}
 

--- a/pkg/collectors/ocean_aws_resource_suggestions.go
+++ b/pkg/collectors/ocean_aws_resource_suggestions.go
@@ -55,49 +55,49 @@ func NewOceanAWSResourceSuggestionsCollector(
 		requestedWorkloadCPU: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_cpu_requested"),
 			"The number of actual CPU units requested by a workload",
-			[]string{"ocean", "workload", "namespace", "name"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name"},
 			nil,
 		),
 		suggestedWorkloadCPU: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_cpu_suggested"),
 			"The number of CPU units suggested for a workload",
-			[]string{"ocean", "workload", "namespace", "name"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name"},
 			nil,
 		),
 		requestedWorkloadMemory: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_memory_requested"),
 			"The number of actual memory units requested by a workload",
-			[]string{"ocean", "workload", "namespace", "name"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name"},
 			nil,
 		),
 		suggestedWorkloadMemory: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_memory_suggested"),
 			"The number of memory units suggested for a workload",
-			[]string{"ocean", "workload", "namespace", "name"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name"},
 			nil,
 		),
 		requestedContainerCPU: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_container_cpu_requested"),
 			"The number of actual CPU units requested by a workload's container",
-			[]string{"ocean", "workload", "namespace", "name", "container"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name", "container"},
 			nil,
 		),
 		suggestedContainerCPU: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_container_cpu_suggested"),
 			"The number of CPU units suggested for a workload's container",
-			[]string{"ocean", "workload", "namespace", "name", "container"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name", "container"},
 			nil,
 		),
 		requestedContainerMemory: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_container_memory_requested"),
 			"The number of actual memory units requested by a workload's container",
-			[]string{"ocean", "workload", "namespace", "name", "container"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name", "container"},
 			nil,
 		),
 		suggestedContainerMemory: prometheus.NewDesc(
 			prometheus.BuildFQName("spotinst", "ocean_aws", "workload_container_memory_suggested"),
 			"The number of memory units suggested for a workload's container",
-			[]string{"ocean", "workload", "namespace", "name", "container"},
+			[]string{"ocean_id", "ocean_name", "workload", "namespace", "name", "container"},
 			nil,
 		),
 	}
@@ -124,26 +124,26 @@ func (c *OceanAWSResourceSuggestionsCollector) Collect(ch chan<- prometheus.Metr
 			OceanID: cluster.ID,
 		}
 
-		clusterID := spotinst.StringValue(cluster.ID)
-
 		output, err := c.client.ListOceanResourceSuggestions(c.ctx, input)
 		if err != nil {
-			c.logger.Error(err, "failed to list resource suggestions", "ocean", clusterID)
+			clusterID := spotinst.StringValue(cluster.ID)
+			c.logger.Error(err, "failed to list resource suggestions", "ocean_id", clusterID)
 			continue
 		}
 
-		c.collectWorkloadSuggestions(ch, output.Suggestions, clusterID)
+		c.collectWorkloadSuggestions(ch, output.Suggestions, cluster)
 	}
 }
 
 func (c *OceanAWSResourceSuggestionsCollector) collectWorkloadSuggestions(
 	ch chan<- prometheus.Metric,
 	suggestions []*aws.ResourceSuggestion,
-	oceanID string,
+	cluster *aws.Cluster,
 ) {
 	for _, suggestion := range suggestions {
 		labelValues := []string{
-			oceanID,
+			spotinst.StringValue(cluster.ID),
+			spotinst.StringValue(cluster.Name),
 			strings.ToLower(spotinst.StringValue(suggestion.ResourceType)),
 			spotinst.StringValue(suggestion.Namespace),
 			spotinst.StringValue(suggestion.ResourceName),

--- a/pkg/collectors/ocean_aws_resource_suggestions_test.go
+++ b/pkg/collectors/ocean_aws_resource_suggestions_test.go
@@ -75,28 +75,28 @@ func TestOceanAWSResourceSuggestionsCollector(t *testing.T) {
 			expected: `
                 # HELP spotinst_ocean_aws_workload_container_cpu_requested The number of actual CPU units requested by a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_cpu_requested gauge
-                spotinst_ocean_aws_workload_container_cpu_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 900
+                spotinst_ocean_aws_workload_container_cpu_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 900
                 # HELP spotinst_ocean_aws_workload_container_cpu_suggested The number of CPU units suggested for a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_cpu_suggested gauge
-                spotinst_ocean_aws_workload_container_cpu_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 200
+                spotinst_ocean_aws_workload_container_cpu_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 200
                 # HELP spotinst_ocean_aws_workload_container_memory_requested The number of actual memory units requested by a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_memory_requested gauge
-                spotinst_ocean_aws_workload_container_memory_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 1800
+                spotinst_ocean_aws_workload_container_memory_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 1800
                 # HELP spotinst_ocean_aws_workload_container_memory_suggested The number of memory units suggested for a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_memory_suggested gauge
-                spotinst_ocean_aws_workload_container_memory_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 90
+                spotinst_ocean_aws_workload_container_memory_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 90
                 # HELP spotinst_ocean_aws_workload_cpu_requested The number of actual CPU units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_requested gauge
-                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 1000
+                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 1000
                 # HELP spotinst_ocean_aws_workload_cpu_suggested The number of CPU units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_suggested gauge
-                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 200
+                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 200
                 # HELP spotinst_ocean_aws_workload_memory_requested The number of actual memory units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_memory_requested gauge
-                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 2000
+                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 2000
                 # HELP spotinst_ocean_aws_workload_memory_suggested The number of memory units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_memory_suggested gauge
-                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 100
+                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 100
             `,
 		},
 		{
@@ -125,36 +125,36 @@ func TestOceanAWSResourceSuggestionsCollector(t *testing.T) {
 			expected: `
                 # HELP spotinst_ocean_aws_workload_container_cpu_requested The number of actual CPU units requested by a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_cpu_requested gauge
-                spotinst_ocean_aws_workload_container_cpu_requested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 899
-                spotinst_ocean_aws_workload_container_cpu_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 900
+                spotinst_ocean_aws_workload_container_cpu_requested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 899
+                spotinst_ocean_aws_workload_container_cpu_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 900
                 # HELP spotinst_ocean_aws_workload_container_cpu_suggested The number of CPU units suggested for a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_cpu_suggested gauge
-                spotinst_ocean_aws_workload_container_cpu_suggested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 199
-                spotinst_ocean_aws_workload_container_cpu_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 200
+                spotinst_ocean_aws_workload_container_cpu_suggested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 199
+                spotinst_ocean_aws_workload_container_cpu_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 200
                 # HELP spotinst_ocean_aws_workload_container_memory_requested The number of actual memory units requested by a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_memory_requested gauge
-                spotinst_ocean_aws_workload_container_memory_requested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 1799
-                spotinst_ocean_aws_workload_container_memory_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 1800
+                spotinst_ocean_aws_workload_container_memory_requested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 1799
+                spotinst_ocean_aws_workload_container_memory_requested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 1800
                 # HELP spotinst_ocean_aws_workload_container_memory_suggested The number of memory units suggested for a workload's container
                 # TYPE spotinst_ocean_aws_workload_container_memory_suggested gauge
-                spotinst_ocean_aws_workload_container_memory_suggested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 89
-                spotinst_ocean_aws_workload_container_memory_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 90
+                spotinst_ocean_aws_workload_container_memory_suggested{container="bar-container",name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 89
+                spotinst_ocean_aws_workload_container_memory_suggested{container="foo-container",name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 90
                 # HELP spotinst_ocean_aws_workload_cpu_requested The number of actual CPU units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_requested gauge
-                spotinst_ocean_aws_workload_cpu_requested{name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 999
-                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 1000
+                spotinst_ocean_aws_workload_cpu_requested{name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 999
+                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 1000
                 # HELP spotinst_ocean_aws_workload_cpu_suggested The number of CPU units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_suggested gauge
-                spotinst_ocean_aws_workload_cpu_suggested{name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 199
-                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 200
+                spotinst_ocean_aws_workload_cpu_suggested{name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 199
+                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 200
                 # HELP spotinst_ocean_aws_workload_memory_requested The number of actual memory units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_memory_requested gauge
-                spotinst_ocean_aws_workload_memory_requested{name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 1999
-                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 2000
+                spotinst_ocean_aws_workload_memory_requested{name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 1999
+                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 2000
                 # HELP spotinst_ocean_aws_workload_memory_suggested The number of memory units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_memory_suggested gauge
-                spotinst_ocean_aws_workload_memory_suggested{name="bar-daemonset",namespace="bar-ns",ocean="foo",workload="daemonset"} 99
-                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 100
+                spotinst_ocean_aws_workload_memory_suggested{name="bar-daemonset",namespace="bar-ns",ocean_id="foo",ocean_name="ocean-foo",workload="daemonset"} 99
+                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 100
             `,
 		},
 		{
@@ -186,20 +186,20 @@ func TestOceanAWSResourceSuggestionsCollector(t *testing.T) {
 			expected: `
                 # HELP spotinst_ocean_aws_workload_cpu_requested The number of actual CPU units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_requested gauge
-                spotinst_ocean_aws_workload_cpu_requested{name="bar-daemonset",namespace="bar-ns",ocean="bar",workload="daemonset"} 999
-                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 1000
+                spotinst_ocean_aws_workload_cpu_requested{name="bar-daemonset",namespace="bar-ns",ocean_id="bar",ocean_name="ocean-bar",workload="daemonset"} 999
+                spotinst_ocean_aws_workload_cpu_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 1000
                 # HELP spotinst_ocean_aws_workload_cpu_suggested The number of CPU units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_cpu_suggested gauge
-                spotinst_ocean_aws_workload_cpu_suggested{name="bar-daemonset",namespace="bar-ns",ocean="bar",workload="daemonset"} 199
-                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 200
+                spotinst_ocean_aws_workload_cpu_suggested{name="bar-daemonset",namespace="bar-ns",ocean_id="bar",ocean_name="ocean-bar",workload="daemonset"} 199
+                spotinst_ocean_aws_workload_cpu_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 200
                 # HELP spotinst_ocean_aws_workload_memory_requested The number of actual memory units requested by a workload
                 # TYPE spotinst_ocean_aws_workload_memory_requested gauge
-                spotinst_ocean_aws_workload_memory_requested{name="bar-daemonset",namespace="bar-ns",ocean="bar",workload="daemonset"} 1999
-                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 2000
+                spotinst_ocean_aws_workload_memory_requested{name="bar-daemonset",namespace="bar-ns",ocean_id="bar",ocean_name="ocean-bar",workload="daemonset"} 1999
+                spotinst_ocean_aws_workload_memory_requested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 2000
                 # HELP spotinst_ocean_aws_workload_memory_suggested The number of memory units suggested for a workload
                 # TYPE spotinst_ocean_aws_workload_memory_suggested gauge
-                spotinst_ocean_aws_workload_memory_suggested{name="bar-daemonset",namespace="bar-ns",ocean="bar",workload="daemonset"} 99
-                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean="foo",workload="deployment"} 100
+                spotinst_ocean_aws_workload_memory_suggested{name="bar-daemonset",namespace="bar-ns",ocean_id="bar",ocean_name="ocean-bar",workload="daemonset"} 99
+                spotinst_ocean_aws_workload_memory_suggested{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 100
             `,
 		},
 	}


### PR DESCRIPTION
This might make it easier to identify ocean clusters than just the ID. The `ocean` label was renamed to `ocean_id` to make it clearer what it contains.