### PR TITLE
fix: unify workload cost metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,8 @@ running costs of the current month and are reset on every 1st.
 
 ```
 spotinst_ocean_aws_cluster_cost{ocean_id="o-12345678",ocean_name="my-ocean"} 301.86862
-spotinst_ocean_aws_daemonset_cost{name="kube-proxy",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 3.4616985
-spotinst_ocean_aws_deployment_cost{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 1.2382613
-spotinst_ocean_aws_job_cost{name="kube-janitor-default-27752145",namespace="sdlc-ops",ocean_id="o-12345678",ocean_name="my-ocean"} 0.0021596102
 spotinst_ocean_aws_namespace_cost{namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean"} 28.858004
-spotinst_ocean_aws_statefulset_cost{name="jenkins",namespace="jenkins",ocean_id="o-12345678",ocean_name="my-ocean"} 2.004659
+spotinst_ocean_aws_workload_cost{name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 1.2382613
 spotinst_ocean_aws_workload_container_cpu_requested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
 spotinst_ocean_aws_workload_container_cpu_suggested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 100
 spotinst_ocean_aws_workload_container_memory_requested{container="coredns",name="coredns",namespace="kube-system",ocean_id="o-12345678",ocean_name="my-ocean",workload="deployment"} 70

--- a/pkg/collectors/ocean_aws_cluster_costs_test.go
+++ b/pkg/collectors/ocean_aws_cluster_costs_test.go
@@ -80,9 +80,9 @@ func TestOceanAWSClusterCostsCollector(t *testing.T) {
                 # HELP spotinst_ocean_aws_namespace_cost Total cost of a namespace
                 # TYPE spotinst_ocean_aws_namespace_cost gauge
                 spotinst_ocean_aws_namespace_cost{namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo"} 190
-                # HELP spotinst_ocean_aws_deployment_cost Total cost of a deployment
-                # TYPE spotinst_ocean_aws_deployment_cost gauge
-                spotinst_ocean_aws_deployment_cost{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo"} 180
+                # HELP spotinst_ocean_aws_workload_cost Total cost of a workload
+                # TYPE spotinst_ocean_aws_workload_cost gauge
+                spotinst_ocean_aws_workload_cost{name="foo-deployment",namespace="foo-ns",ocean_id="foo",ocean_name="ocean-foo",workload="deployment"} 180
             `,
 		},
 	}


### PR DESCRIPTION
Unifies the `spotinst_ocean_aws_daemonset_cost`,
`spotinst_ocean_aws_deployment_cost`, `spotinst_ocean_aws_job_cost` and `spotinst_ocean_aws_statefulset_cost` metrics into a single metric named `spotinst_ocean_aws_workload_cost`. The workload type will be denoted by the `workload` label instead. It is equivalent how this is handled for the resource suggestion metrics (e.g.
`spotinst_ocean_aws_workload_cpu_suggested`).

This change will simplify prometheus queries which aggregate the cost of all possible workloads. Before we needed to do something like this if we wanted to calculate the cost of a named workload in a particular namespace and cluster:

```
sum by(ocean_id,namespace) (spotinst_ocean_aws_deployment_cost{ocean_id=~"$ocean_id",namespace=~"$namespace",name=~"$name"} or spotinst_ocean_aws_daemonset_cost{ocean_id=~"$ocean_id",namespace=~"$namespace",name=~"$name"} or spotinst_ocean_aws_statefulset_cost{ocean_id=~"$ocean_id",namespace=~"$namespace",name=~"$name"} or spotinst_ocean_aws_job_cost{ocean_id=~"$ocean_id",namespace=~"$namespace",name=~"$name"})
```

After this change this just becomes:

```
sum by(ocean_id,namespace) (spotinst_ocean_aws_workload_cost{ocean_id=~"$ocean_id",namespace=~"$namespace",name=~"$name"})
```

Furthermore this now makes it easier to parameterizes Grafana dashboards related to workload costs over the workload type via the `workload` label value. With the previous metrics format this was not possible.