### PR TITLE
feat: add support for propagating custom resource labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/prometheus/client_golang v1.19.0
+	github.com/spf13/pflag v1.0.5
 	github.com/spotinst/spotinst-sdk-go v1.343.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spotinst/spotinst-sdk-go v1.343.0 h1:Z2uMEBt0QPJ6qplxibQiqL28ZPnOUySBQhHCGCbI7is=
 github.com/spotinst/spotinst-sdk-go v1.343.0/go.mod h1:Tn4/eb0SFY6IXmxz71CClujvbD/PuT+EO6Ta8v6AML4=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=

--- a/pkg/labels/mappings.go
+++ b/pkg/labels/mappings.go
@@ -1,0 +1,102 @@
+package labels
+
+import (
+	"errors"
+	"strings"
+)
+
+var errEmptyLabelName = errors.New("label names must not be empty")
+
+// Mapping defines a mapping between a Kubernetes resource label and a
+// Prometheus label.
+type Mapping struct {
+	resourceLabelName   string
+	prometheusLabelName string
+}
+
+// Mappings is a list of label mappings.
+type Mappings []Mapping
+
+// ParseMappings parses label mappings from an input string.
+//
+// Returns an error if the input is malformed.
+func ParseMappings(input string) (Mappings, error) {
+	pairs := strings.Split(input, ",")
+	mappings := make(Mappings, 0, len(pairs))
+
+	for _, pair := range pairs {
+		labels := strings.SplitN(pair, "=", 2)
+
+		resourceLabel := labels[0]
+		prometheusLabel := resourceLabel
+		if len(labels) == 2 {
+			prometheusLabel = labels[1]
+		}
+
+		if resourceLabel == "" || prometheusLabel == "" {
+			return nil, errEmptyLabelName
+		}
+
+		mappings = append(mappings, Mapping{
+			resourceLabelName:   resourceLabel,
+			prometheusLabelName: prometheusLabel,
+		})
+	}
+
+	return mappings, nil
+}
+
+// LabelNames returns the names of the Prometheus labels.
+func (m Mappings) LabelNames() []string {
+	values := make([]string, 0, len(m))
+
+	for _, mapping := range m {
+		values = append(values, mapping.prometheusLabelName)
+	}
+
+	return values
+}
+
+// LabelValues extracts the values for the configured Prometheus labels from
+// the provided labels map.
+func (m Mappings) LabelValues(labels map[string]string) []string {
+	values := make([]string, 0, len(m))
+
+	for _, mapping := range m {
+		values = append(values, labels[mapping.resourceLabelName])
+	}
+
+	return values
+}
+
+// Set implements pflag.Value.
+func (m *Mappings) Set(value string) error {
+	mappings, err := ParseMappings(value)
+	if err != nil {
+		return err
+	}
+
+	*m = append(*m, mappings...)
+	return nil
+}
+
+// String implements pflag.Value.
+func (m Mappings) String() string {
+	var sb strings.Builder
+
+	for i, mapping := range m {
+		if i > 0 {
+			sb.WriteRune(',')
+		}
+		sb.WriteString(mapping.resourceLabelName)
+		sb.WriteRune('=')
+		sb.WriteString(mapping.prometheusLabelName)
+	}
+
+	return sb.String()
+}
+
+// Type implements pflag.Value.
+func (m Mappings) Type() string {
+	return "resource-label[=prometheus-label]"
+}

--- a/pkg/labels/mappings_test.go
+++ b/pkg/labels/mappings_test.go
@@ -1,0 +1,55 @@
+package labels
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMappings(t *testing.T) {
+	t.Run("valid input", func(t *testing.T) {
+		expectedMappings := Mappings{
+			{resourceLabelName: "foo", prometheusLabelName: "foo"},
+			{resourceLabelName: "bar", prometheusLabelName: "baz"},
+		}
+
+		resourceLabels := map[string]string{
+			"bar": "bar-value",
+			"qux": "qux-value",
+		}
+
+		mappings, err := ParseMappings("foo,bar=baz")
+		assert.NoError(t, err)
+		assert.Equal(t, expectedMappings, mappings)
+		assert.Equal(t, []string{"foo", "baz"}, mappings.LabelNames())
+		assert.Equal(t, []string{"", "bar-value"}, mappings.LabelValues(resourceLabels))
+		assert.Equal(t, "foo=foo,bar=baz", mappings.String())
+	})
+
+	t.Run("invalid input", func(t *testing.T) {
+		for _, input := range []string{"", "foo=,bar=baz", "=foo"} {
+			_, err := ParseMappings(input)
+			assert.Error(t, err)
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		var mappings Mappings
+
+		expectedMappings := Mappings{
+			{resourceLabelName: "foo", prometheusLabelName: "foo"},
+		}
+
+		assert.NoError(t, mappings.Set("foo"))
+		assert.Equal(t, expectedMappings, mappings)
+
+		expectedMappings = Mappings{
+			{resourceLabelName: "foo", prometheusLabelName: "foo"},
+			{resourceLabelName: "bar", prometheusLabelName: "baz"},
+			{resourceLabelName: "baz", prometheusLabelName: "qux"},
+		}
+
+		assert.NoError(t, mappings.Set("bar=baz,baz=qux"))
+		assert.Equal(t, expectedMappings, mappings)
+	})
+}


### PR DESCRIPTION
The new CLI flag `--resource-labels` allows configuring Kubernetes resource labels that should be propagated into Prometheus metric labels.

The flag can be specified multiple times and expects a comma-separated list of Kubernetes resource label names with an optional mapping to a Prometheus label.

Examples:

- `team` propagates the value of the Kubernetes label `team` into a Prometheus label of the same name.
- `app.kubernetes.io/name=app` propagates the value of the Kubernetes label `app.kubernetes.io/name` into the Prometheus label `app`.

If a resource label is configured but not available on a resource, the Prometheus label's value will default to an empty string.

The following metrics benefit from this change:

- `spotinst_ocean_aws_namespace_cost`
- `spotinst_ocean_aws_workload_cost`

All other metrics (e.g. resource suggestions) do not benefit from this change because there are no resource labels returned from the spotinst API. Support could be added in the future, at the expense of additional API calls to enrich the currently available data.

A helm chart change to support this feature will be provided in a separate PR.