### PR TITLE
feat(helm): make container args configurable

### DIFF
--- a/charts/spotinst-metrics-exporter/Chart.yaml
+++ b/charts/spotinst-metrics-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: spotinst-metrics-exporter
 description: A prometheus exporter for metrics from Spotinst
 type: application
-version: 0.2.3
-appVersion: "v0.2.3"
+version: 0.2.4
+appVersion: "v0.2.4"

--- a/charts/spotinst-metrics-exporter/templates/deployment.yaml
+++ b/charts/spotinst-metrics-exporter/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "spotinst-metrics-exporter.fullname" . }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/spotinst-metrics-exporter/values.yaml
+++ b/charts/spotinst-metrics-exporter/values.yaml
@@ -52,3 +52,5 @@ affinity: {}
 spotinst:
   account: ""
   token: ""
+
+args: []


### PR DESCRIPTION
This enables the usage of the custom container args like the `--resource-labels` flag introduced in
https://github.com/Bonial-International-GmbH/spotinst-metrics-exporter/pull/53.