### PR TITLE
chore: update golang alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 as builder
+FROM golang:1.25.1-alpine as builder
 
 WORKDIR /src
 


### PR DESCRIPTION
Also changes to always use the latest alpine image as it works better with renovate. We still use a specific golan version